### PR TITLE
add: mask_correlated_samples_2 in AttnGAN+CL

### DIFF
--- a/AttnGAN+CL/code/masks.py
+++ b/AttnGAN+CL/code/masks.py
@@ -7,3 +7,11 @@ def mask_correlated_samples(args):
         mask[i, args.batch_size + i] = 0
         mask[args.batch_size + i, i] = 0
     return mask
+
+def mask_correlated_samples_2(batch_size):
+    mask = torch.ones((batch_size * 2, batch_size * 2), dtype=bool)
+    mask = mask.fill_diagonal_(0)
+    for i in range(batch_size):
+        mask[i, batch_size + i] = 0
+        mask[batch_size + i, i] = 0
+    return mask


### PR DESCRIPTION
I think the pretrain_DAMSM.py works reliably only when this function is also at masks.py in the AttnGAN+CL folder.